### PR TITLE
Add support for OCCT variants novtk/all

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,24 +8,44 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_numpy1.22python3.10.____cpython:
-        CONFIG: linux_64_numpy1.22python3.10.____cpython
+      linux_64_numpy1.22python3.10.____cpythonvariantall:
+        CONFIG: linux_64_numpy1.22python3.10.____cpythonvariantall
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_numpy1.22python3.8.____cpython:
-        CONFIG: linux_64_numpy1.22python3.8.____cpython
+      linux_64_numpy1.22python3.10.____cpythonvariantnovtk:
+        CONFIG: linux_64_numpy1.22python3.10.____cpythonvariantnovtk
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_numpy1.22python3.9.____cpython:
-        CONFIG: linux_64_numpy1.22python3.9.____cpython
+      linux_64_numpy1.22python3.8.____cpythonvariantall:
+        CONFIG: linux_64_numpy1.22python3.8.____cpythonvariantall
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_numpy1.23python3.11.____cpython:
-        CONFIG: linux_64_numpy1.23python3.11.____cpython
+      linux_64_numpy1.22python3.8.____cpythonvariantnovtk:
+        CONFIG: linux_64_numpy1.22python3.8.____cpythonvariantnovtk
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_numpy1.26python3.12.____cpython:
-        CONFIG: linux_64_numpy1.26python3.12.____cpython
+      linux_64_numpy1.22python3.9.____cpythonvariantall:
+        CONFIG: linux_64_numpy1.22python3.9.____cpythonvariantall
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_numpy1.22python3.9.____cpythonvariantnovtk:
+        CONFIG: linux_64_numpy1.22python3.9.____cpythonvariantnovtk
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_numpy1.23python3.11.____cpythonvariantall:
+        CONFIG: linux_64_numpy1.23python3.11.____cpythonvariantall
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_numpy1.23python3.11.____cpythonvariantnovtk:
+        CONFIG: linux_64_numpy1.23python3.11.____cpythonvariantnovtk
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_numpy1.26python3.12.____cpythonvariantall:
+        CONFIG: linux_64_numpy1.26python3.12.____cpythonvariantall
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_numpy1.26python3.12.____cpythonvariantnovtk:
+        CONFIG: linux_64_numpy1.26python3.12.____cpythonvariantnovtk
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360
@@ -41,6 +61,9 @@ jobs:
 
   - script: |
         export CI=azure
+        export flow_run_id=azure_$(Build.BuildNumber).$(System.JobAttempt)
+        export remote_url=$(Build.Repository.Uri)
+        export sha=$(Build.SourceVersion)
         export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
         export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
         if [[ "${BUILD_REASON:-}" == "PullRequest" ]]; then

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,35 +8,65 @@ jobs:
     vmImage: macOS-11
   strategy:
     matrix:
-      osx_64_numpy1.22python3.10.____cpython:
-        CONFIG: osx_64_numpy1.22python3.10.____cpython
+      osx_64_numpy1.22python3.10.____cpythonvariantall:
+        CONFIG: osx_64_numpy1.22python3.10.____cpythonvariantall
         UPLOAD_PACKAGES: 'True'
-      osx_64_numpy1.22python3.8.____cpython:
-        CONFIG: osx_64_numpy1.22python3.8.____cpython
+      osx_64_numpy1.22python3.10.____cpythonvariantnovtk:
+        CONFIG: osx_64_numpy1.22python3.10.____cpythonvariantnovtk
         UPLOAD_PACKAGES: 'True'
-      osx_64_numpy1.22python3.9.____cpython:
-        CONFIG: osx_64_numpy1.22python3.9.____cpython
+      osx_64_numpy1.22python3.8.____cpythonvariantall:
+        CONFIG: osx_64_numpy1.22python3.8.____cpythonvariantall
         UPLOAD_PACKAGES: 'True'
-      osx_64_numpy1.23python3.11.____cpython:
-        CONFIG: osx_64_numpy1.23python3.11.____cpython
+      osx_64_numpy1.22python3.8.____cpythonvariantnovtk:
+        CONFIG: osx_64_numpy1.22python3.8.____cpythonvariantnovtk
         UPLOAD_PACKAGES: 'True'
-      osx_64_numpy1.26python3.12.____cpython:
-        CONFIG: osx_64_numpy1.26python3.12.____cpython
+      osx_64_numpy1.22python3.9.____cpythonvariantall:
+        CONFIG: osx_64_numpy1.22python3.9.____cpythonvariantall
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_numpy1.22python3.10.____cpython:
-        CONFIG: osx_arm64_numpy1.22python3.10.____cpython
+      osx_64_numpy1.22python3.9.____cpythonvariantnovtk:
+        CONFIG: osx_64_numpy1.22python3.9.____cpythonvariantnovtk
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_numpy1.22python3.8.____cpython:
-        CONFIG: osx_arm64_numpy1.22python3.8.____cpython
+      osx_64_numpy1.23python3.11.____cpythonvariantall:
+        CONFIG: osx_64_numpy1.23python3.11.____cpythonvariantall
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_numpy1.22python3.9.____cpython:
-        CONFIG: osx_arm64_numpy1.22python3.9.____cpython
+      osx_64_numpy1.23python3.11.____cpythonvariantnovtk:
+        CONFIG: osx_64_numpy1.23python3.11.____cpythonvariantnovtk
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_numpy1.23python3.11.____cpython:
-        CONFIG: osx_arm64_numpy1.23python3.11.____cpython
+      osx_64_numpy1.26python3.12.____cpythonvariantall:
+        CONFIG: osx_64_numpy1.26python3.12.____cpythonvariantall
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_numpy1.26python3.12.____cpython:
-        CONFIG: osx_arm64_numpy1.26python3.12.____cpython
+      osx_64_numpy1.26python3.12.____cpythonvariantnovtk:
+        CONFIG: osx_64_numpy1.26python3.12.____cpythonvariantnovtk
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_numpy1.22python3.10.____cpythonvariantall:
+        CONFIG: osx_arm64_numpy1.22python3.10.____cpythonvariantall
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_numpy1.22python3.10.____cpythonvariantnovtk:
+        CONFIG: osx_arm64_numpy1.22python3.10.____cpythonvariantnovtk
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_numpy1.22python3.8.____cpythonvariantall:
+        CONFIG: osx_arm64_numpy1.22python3.8.____cpythonvariantall
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_numpy1.22python3.8.____cpythonvariantnovtk:
+        CONFIG: osx_arm64_numpy1.22python3.8.____cpythonvariantnovtk
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_numpy1.22python3.9.____cpythonvariantall:
+        CONFIG: osx_arm64_numpy1.22python3.9.____cpythonvariantall
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_numpy1.22python3.9.____cpythonvariantnovtk:
+        CONFIG: osx_arm64_numpy1.22python3.9.____cpythonvariantnovtk
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_numpy1.23python3.11.____cpythonvariantall:
+        CONFIG: osx_arm64_numpy1.23python3.11.____cpythonvariantall
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_numpy1.23python3.11.____cpythonvariantnovtk:
+        CONFIG: osx_arm64_numpy1.23python3.11.____cpythonvariantnovtk
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_numpy1.26python3.12.____cpythonvariantall:
+        CONFIG: osx_arm64_numpy1.26python3.12.____cpythonvariantall
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_numpy1.26python3.12.____cpythonvariantnovtk:
+        CONFIG: osx_arm64_numpy1.26python3.12.____cpythonvariantnovtk
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
 
@@ -44,6 +74,9 @@ jobs:
   # TODO: Fast finish on azure pipelines?
   - script: |
       export CI=azure
+      export flow_run_id=azure_$(Build.BuildNumber).$(System.JobAttempt)
+      export remote_url=$(Build.Repository.Uri)
+      export sha=$(Build.SourceVersion)
       export OSX_FORCE_SDK_DOWNLOAD="1"
       export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
       export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -8,20 +8,35 @@ jobs:
     vmImage: windows-2022
   strategy:
     matrix:
-      win_64_numpy1.22python3.10.____cpython:
-        CONFIG: win_64_numpy1.22python3.10.____cpython
+      win_64_numpy1.22python3.10.____cpythonvariantall:
+        CONFIG: win_64_numpy1.22python3.10.____cpythonvariantall
         UPLOAD_PACKAGES: 'True'
-      win_64_numpy1.22python3.8.____cpython:
-        CONFIG: win_64_numpy1.22python3.8.____cpython
+      win_64_numpy1.22python3.10.____cpythonvariantnovtk:
+        CONFIG: win_64_numpy1.22python3.10.____cpythonvariantnovtk
         UPLOAD_PACKAGES: 'True'
-      win_64_numpy1.22python3.9.____cpython:
-        CONFIG: win_64_numpy1.22python3.9.____cpython
+      win_64_numpy1.22python3.8.____cpythonvariantall:
+        CONFIG: win_64_numpy1.22python3.8.____cpythonvariantall
         UPLOAD_PACKAGES: 'True'
-      win_64_numpy1.23python3.11.____cpython:
-        CONFIG: win_64_numpy1.23python3.11.____cpython
+      win_64_numpy1.22python3.8.____cpythonvariantnovtk:
+        CONFIG: win_64_numpy1.22python3.8.____cpythonvariantnovtk
         UPLOAD_PACKAGES: 'True'
-      win_64_numpy1.26python3.12.____cpython:
-        CONFIG: win_64_numpy1.26python3.12.____cpython
+      win_64_numpy1.22python3.9.____cpythonvariantall:
+        CONFIG: win_64_numpy1.22python3.9.____cpythonvariantall
+        UPLOAD_PACKAGES: 'True'
+      win_64_numpy1.22python3.9.____cpythonvariantnovtk:
+        CONFIG: win_64_numpy1.22python3.9.____cpythonvariantnovtk
+        UPLOAD_PACKAGES: 'True'
+      win_64_numpy1.23python3.11.____cpythonvariantall:
+        CONFIG: win_64_numpy1.23python3.11.____cpythonvariantall
+        UPLOAD_PACKAGES: 'True'
+      win_64_numpy1.23python3.11.____cpythonvariantnovtk:
+        CONFIG: win_64_numpy1.23python3.11.____cpythonvariantnovtk
+        UPLOAD_PACKAGES: 'True'
+      win_64_numpy1.26python3.12.____cpythonvariantall:
+        CONFIG: win_64_numpy1.26python3.12.____cpythonvariantall
+        UPLOAD_PACKAGES: 'True'
+      win_64_numpy1.26python3.12.____cpythonvariantnovtk:
+        CONFIG: win_64_numpy1.26python3.12.____cpythonvariantnovtk
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables:
@@ -54,6 +69,9 @@ jobs:
         PYTHONUNBUFFERED: 1
         CONFIG: $(CONFIG)
         CI: azure
+        flow_run_id: azure_$(Build.BuildNumber).$(System.JobAttempt)
+        remote_url: $(Build.Repository.Uri)
+        sha: $(Build.SourceVersion)
         UPLOAD_PACKAGES: $(UPLOAD_PACKAGES)
         UPLOAD_TEMP: $(UPLOAD_TEMP)
         BINSTAR_TOKEN: $(BINSTAR_TOKEN)

--- a/.ci_support/linux_64_numpy1.22python3.10.____cpythonvariantall.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.10.____cpythonvariantall.yaml
@@ -11,7 +11,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:
-- '1.26'
+- '1.22'
 occt:
 - 7.7.2
 pin_run_as_build:
@@ -21,9 +21,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.12.* *_cpython
+- 3.10.* *_cpython
 target_platform:
 - linux-64
+variant:
+- all
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/linux_64_numpy1.22python3.10.____cpythonvariantnovtk.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.10.____cpythonvariantnovtk.yaml
@@ -1,0 +1,31 @@
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+numpy:
+- '1.22'
+occt:
+- 7.7.2
+pin_run_as_build:
+  occt:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+target_platform:
+- linux-64
+variant:
+- novtk
+zip_keys:
+- - python
+  - numpy

--- a/.ci_support/linux_64_numpy1.22python3.8.____cpythonvariantall.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.8.____cpythonvariantall.yaml
@@ -1,17 +1,17 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '16'
-macos_machine:
-- x86_64-apple-darwin13.4.0
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:
-- '1.23'
+- '1.22'
 occt:
 - 7.7.2
 pin_run_as_build:
@@ -21,9 +21,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.11.* *_cpython
+- 3.8.* *_cpython
 target_platform:
-- osx-64
+- linux-64
+variant:
+- all
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/linux_64_numpy1.22python3.8.____cpythonvariantnovtk.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.8.____cpythonvariantnovtk.yaml
@@ -1,0 +1,31 @@
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+numpy:
+- '1.22'
+occt:
+- 7.7.2
+pin_run_as_build:
+  occt:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+target_platform:
+- linux-64
+variant:
+- novtk
+zip_keys:
+- - python
+  - numpy

--- a/.ci_support/linux_64_numpy1.22python3.9.____cpythonvariantall.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.9.____cpythonvariantall.yaml
@@ -1,0 +1,31 @@
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+numpy:
+- '1.22'
+occt:
+- 7.7.2
+pin_run_as_build:
+  occt:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+target_platform:
+- linux-64
+variant:
+- all
+zip_keys:
+- - python
+  - numpy

--- a/.ci_support/linux_64_numpy1.22python3.9.____cpythonvariantnovtk.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.9.____cpythonvariantnovtk.yaml
@@ -1,15 +1,15 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '16'
-macos_machine:
-- arm64-apple-darwin20.0.0
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:
 - '1.22'
 occt:
@@ -21,9 +21,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.9.* *_cpython
 target_platform:
-- osx-arm64
+- linux-64
+variant:
+- novtk
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/linux_64_numpy1.23python3.11.____cpythonvariantall.yaml
+++ b/.ci_support/linux_64_numpy1.23python3.11.____cpythonvariantall.yaml
@@ -1,0 +1,31 @@
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+numpy:
+- '1.23'
+occt:
+- 7.7.2
+pin_run_as_build:
+  occt:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+target_platform:
+- linux-64
+variant:
+- all
+zip_keys:
+- - python
+  - numpy

--- a/.ci_support/linux_64_numpy1.23python3.11.____cpythonvariantnovtk.yaml
+++ b/.ci_support/linux_64_numpy1.23python3.11.____cpythonvariantnovtk.yaml
@@ -11,7 +11,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:
-- '1.22'
+- '1.23'
 occt:
 - 7.7.2
 pin_run_as_build:
@@ -21,9 +21,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.11.* *_cpython
 target_platform:
 - linux-64
+variant:
+- novtk
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/linux_64_numpy1.26python3.12.____cpythonvariantall.yaml
+++ b/.ci_support/linux_64_numpy1.26python3.12.____cpythonvariantall.yaml
@@ -1,9 +1,15 @@
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- vs2019
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:
 - '1.26'
 occt:
@@ -17,7 +23,9 @@ pin_run_as_build:
 python:
 - 3.12.* *_cpython
 target_platform:
-- win-64
+- linux-64
+variant:
+- all
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/linux_64_numpy1.26python3.12.____cpythonvariantnovtk.yaml
+++ b/.ci_support/linux_64_numpy1.26python3.12.____cpythonvariantnovtk.yaml
@@ -1,0 +1,31 @@
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+numpy:
+- '1.26'
+occt:
+- 7.7.2
+pin_run_as_build:
+  occt:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+target_platform:
+- linux-64
+variant:
+- novtk
+zip_keys:
+- - python
+  - numpy

--- a/.ci_support/osx_64_numpy1.22python3.10.____cpythonvariantall.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.10.____cpythonvariantall.yaml
@@ -1,5 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '10.9'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -9,7 +9,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '16'
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 numpy:
 - '1.22'
 occt:
@@ -21,9 +21,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.10.* *_cpython
 target_platform:
-- osx-arm64
+- osx-64
+variant:
+- all
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/osx_64_numpy1.22python3.10.____cpythonvariantnovtk.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.10.____cpythonvariantnovtk.yaml
@@ -1,5 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '10.9'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -9,7 +9,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '16'
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 numpy:
 - '1.22'
 occt:
@@ -21,9 +21,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.10.* *_cpython
 target_platform:
-- osx-arm64
+- osx-64
+variant:
+- novtk
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/osx_64_numpy1.22python3.8.____cpythonvariantall.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.8.____cpythonvariantall.yaml
@@ -1,5 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '10.9'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -9,9 +9,9 @@ cxx_compiler:
 cxx_compiler_version:
 - '16'
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 numpy:
-- '1.23'
+- '1.22'
 occt:
 - 7.7.2
 pin_run_as_build:
@@ -21,9 +21,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.11.* *_cpython
+- 3.8.* *_cpython
 target_platform:
-- osx-arm64
+- osx-64
+variant:
+- all
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/osx_64_numpy1.22python3.8.____cpythonvariantnovtk.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.8.____cpythonvariantnovtk.yaml
@@ -1,0 +1,31 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '16'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+numpy:
+- '1.22'
+occt:
+- 7.7.2
+pin_run_as_build:
+  occt:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+target_platform:
+- osx-64
+variant:
+- novtk
+zip_keys:
+- - python
+  - numpy

--- a/.ci_support/osx_64_numpy1.22python3.9.____cpythonvariantall.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.9.____cpythonvariantall.yaml
@@ -1,0 +1,31 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '16'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+numpy:
+- '1.22'
+occt:
+- 7.7.2
+pin_run_as_build:
+  occt:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+target_platform:
+- osx-64
+variant:
+- all
+zip_keys:
+- - python
+  - numpy

--- a/.ci_support/osx_64_numpy1.22python3.9.____cpythonvariantnovtk.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.9.____cpythonvariantnovtk.yaml
@@ -1,0 +1,31 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '16'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+numpy:
+- '1.22'
+occt:
+- 7.7.2
+pin_run_as_build:
+  occt:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+target_platform:
+- osx-64
+variant:
+- novtk
+zip_keys:
+- - python
+  - numpy

--- a/.ci_support/osx_64_numpy1.23python3.11.____cpythonvariantall.yaml
+++ b/.ci_support/osx_64_numpy1.23python3.11.____cpythonvariantall.yaml
@@ -1,0 +1,31 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '16'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+numpy:
+- '1.23'
+occt:
+- 7.7.2
+pin_run_as_build:
+  occt:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+target_platform:
+- osx-64
+variant:
+- all
+zip_keys:
+- - python
+  - numpy

--- a/.ci_support/osx_64_numpy1.23python3.11.____cpythonvariantnovtk.yaml
+++ b/.ci_support/osx_64_numpy1.23python3.11.____cpythonvariantnovtk.yaml
@@ -1,0 +1,31 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '16'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+numpy:
+- '1.23'
+occt:
+- 7.7.2
+pin_run_as_build:
+  occt:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+target_platform:
+- osx-64
+variant:
+- novtk
+zip_keys:
+- - python
+  - numpy

--- a/.ci_support/osx_64_numpy1.26python3.12.____cpythonvariantall.yaml
+++ b/.ci_support/osx_64_numpy1.26python3.12.____cpythonvariantall.yaml
@@ -1,0 +1,31 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '16'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+numpy:
+- '1.26'
+occt:
+- 7.7.2
+pin_run_as_build:
+  occt:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+target_platform:
+- osx-64
+variant:
+- all
+zip_keys:
+- - python
+  - numpy

--- a/.ci_support/osx_64_numpy1.26python3.12.____cpythonvariantnovtk.yaml
+++ b/.ci_support/osx_64_numpy1.26python3.12.____cpythonvariantnovtk.yaml
@@ -1,0 +1,31 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '16'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+numpy:
+- '1.26'
+occt:
+- 7.7.2
+pin_run_as_build:
+  occt:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+target_platform:
+- osx-64
+variant:
+- novtk
+zip_keys:
+- - python
+  - numpy

--- a/.ci_support/osx_arm64_numpy1.22python3.10.____cpythonvariantall.yaml
+++ b/.ci_support/osx_arm64_numpy1.22python3.10.____cpythonvariantall.yaml
@@ -1,0 +1,31 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '16'
+macos_machine:
+- arm64-apple-darwin20.0.0
+numpy:
+- '1.22'
+occt:
+- 7.7.2
+pin_run_as_build:
+  occt:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+target_platform:
+- osx-arm64
+variant:
+- all
+zip_keys:
+- - python
+  - numpy

--- a/.ci_support/osx_arm64_numpy1.22python3.10.____cpythonvariantnovtk.yaml
+++ b/.ci_support/osx_arm64_numpy1.22python3.10.____cpythonvariantnovtk.yaml
@@ -1,0 +1,31 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '16'
+macos_machine:
+- arm64-apple-darwin20.0.0
+numpy:
+- '1.22'
+occt:
+- 7.7.2
+pin_run_as_build:
+  occt:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+target_platform:
+- osx-arm64
+variant:
+- novtk
+zip_keys:
+- - python
+  - numpy

--- a/.ci_support/osx_arm64_numpy1.22python3.8.____cpythonvariantall.yaml
+++ b/.ci_support/osx_arm64_numpy1.22python3.8.____cpythonvariantall.yaml
@@ -1,5 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -9,7 +9,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '16'
 macos_machine:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 numpy:
 - '1.22'
 occt:
@@ -23,7 +23,9 @@ pin_run_as_build:
 python:
 - 3.8.* *_cpython
 target_platform:
-- osx-64
+- osx-arm64
+variant:
+- all
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/osx_arm64_numpy1.22python3.8.____cpythonvariantnovtk.yaml
+++ b/.ci_support/osx_arm64_numpy1.22python3.8.____cpythonvariantnovtk.yaml
@@ -1,0 +1,31 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '16'
+macos_machine:
+- arm64-apple-darwin20.0.0
+numpy:
+- '1.22'
+occt:
+- 7.7.2
+pin_run_as_build:
+  occt:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+target_platform:
+- osx-arm64
+variant:
+- novtk
+zip_keys:
+- - python
+  - numpy

--- a/.ci_support/osx_arm64_numpy1.22python3.9.____cpythonvariantall.yaml
+++ b/.ci_support/osx_arm64_numpy1.22python3.9.____cpythonvariantall.yaml
@@ -1,9 +1,15 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- vs2019
+- clangxx
+cxx_compiler_version:
+- '16'
+macos_machine:
+- arm64-apple-darwin20.0.0
 numpy:
 - '1.22'
 occt:
@@ -17,7 +23,9 @@ pin_run_as_build:
 python:
 - 3.9.* *_cpython
 target_platform:
-- win-64
+- osx-arm64
+variant:
+- all
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/osx_arm64_numpy1.22python3.9.____cpythonvariantnovtk.yaml
+++ b/.ci_support/osx_arm64_numpy1.22python3.9.____cpythonvariantnovtk.yaml
@@ -1,0 +1,31 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '16'
+macos_machine:
+- arm64-apple-darwin20.0.0
+numpy:
+- '1.22'
+occt:
+- 7.7.2
+pin_run_as_build:
+  occt:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+target_platform:
+- osx-arm64
+variant:
+- novtk
+zip_keys:
+- - python
+  - numpy

--- a/.ci_support/osx_arm64_numpy1.23python3.11.____cpythonvariantall.yaml
+++ b/.ci_support/osx_arm64_numpy1.23python3.11.____cpythonvariantall.yaml
@@ -1,5 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -9,9 +9,9 @@ cxx_compiler:
 cxx_compiler_version:
 - '16'
 macos_machine:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 numpy:
-- '1.26'
+- '1.23'
 occt:
 - 7.7.2
 pin_run_as_build:
@@ -21,9 +21,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.12.* *_cpython
+- 3.11.* *_cpython
 target_platform:
-- osx-64
+- osx-arm64
+variant:
+- all
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/osx_arm64_numpy1.23python3.11.____cpythonvariantnovtk.yaml
+++ b/.ci_support/osx_arm64_numpy1.23python3.11.____cpythonvariantnovtk.yaml
@@ -11,7 +11,7 @@ cxx_compiler_version:
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:
-- '1.26'
+- '1.23'
 occt:
 - 7.7.2
 pin_run_as_build:
@@ -21,9 +21,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.12.* *_cpython
+- 3.11.* *_cpython
 target_platform:
 - osx-arm64
+variant:
+- novtk
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/osx_arm64_numpy1.26python3.12.____cpythonvariantall.yaml
+++ b/.ci_support/osx_arm64_numpy1.26python3.12.____cpythonvariantall.yaml
@@ -1,11 +1,17 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- vs2019
+- clangxx
+cxx_compiler_version:
+- '16'
+macos_machine:
+- arm64-apple-darwin20.0.0
 numpy:
-- '1.22'
+- '1.26'
 occt:
 - 7.7.2
 pin_run_as_build:
@@ -15,9 +21,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.12.* *_cpython
 target_platform:
-- win-64
+- osx-arm64
+variant:
+- all
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/osx_arm64_numpy1.26python3.12.____cpythonvariantnovtk.yaml
+++ b/.ci_support/osx_arm64_numpy1.26python3.12.____cpythonvariantnovtk.yaml
@@ -1,0 +1,31 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '16'
+macos_machine:
+- arm64-apple-darwin20.0.0
+numpy:
+- '1.26'
+occt:
+- 7.7.2
+pin_run_as_build:
+  occt:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+target_platform:
+- osx-arm64
+variant:
+- novtk
+zip_keys:
+- - python
+  - numpy

--- a/.ci_support/win_64_numpy1.22python3.10.____cpythonvariantall.yaml
+++ b/.ci_support/win_64_numpy1.22python3.10.____cpythonvariantall.yaml
@@ -1,17 +1,11 @@
-cdt_name:
-- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
-cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- vs2019
 numpy:
-- '1.23'
+- '1.22'
 occt:
 - 7.7.2
 pin_run_as_build:
@@ -21,9 +15,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.11.* *_cpython
+- 3.10.* *_cpython
 target_platform:
-- linux-64
+- win-64
+variant:
+- all
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/win_64_numpy1.22python3.10.____cpythonvariantnovtk.yaml
+++ b/.ci_support/win_64_numpy1.22python3.10.____cpythonvariantnovtk.yaml
@@ -1,15 +1,9 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
-cxx_compiler_version:
-- '16'
-macos_machine:
-- x86_64-apple-darwin13.4.0
+- vs2019
 numpy:
 - '1.22'
 occt:
@@ -21,9 +15,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.10.* *_cpython
 target_platform:
-- osx-64
+- win-64
+variant:
+- novtk
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/win_64_numpy1.22python3.8.____cpythonvariantall.yaml
+++ b/.ci_support/win_64_numpy1.22python3.8.____cpythonvariantall.yaml
@@ -5,7 +5,7 @@ channel_targets:
 cxx_compiler:
 - vs2019
 numpy:
-- '1.23'
+- '1.22'
 occt:
 - 7.7.2
 pin_run_as_build:
@@ -15,9 +15,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.11.* *_cpython
+- 3.8.* *_cpython
 target_platform:
 - win-64
+variant:
+- all
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/win_64_numpy1.22python3.8.____cpythonvariantnovtk.yaml
+++ b/.ci_support/win_64_numpy1.22python3.8.____cpythonvariantnovtk.yaml
@@ -1,15 +1,9 @@
-cdt_name:
-- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
-cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- vs2019
 numpy:
 - '1.22'
 occt:
@@ -21,9 +15,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.8.* *_cpython
 target_platform:
-- linux-64
+- win-64
+variant:
+- novtk
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/win_64_numpy1.22python3.9.____cpythonvariantall.yaml
+++ b/.ci_support/win_64_numpy1.22python3.9.____cpythonvariantall.yaml
@@ -1,15 +1,9 @@
-cdt_name:
-- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
-cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- vs2019
 numpy:
 - '1.22'
 occt:
@@ -21,9 +15,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.9.* *_cpython
 target_platform:
-- linux-64
+- win-64
+variant:
+- all
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/win_64_numpy1.22python3.9.____cpythonvariantnovtk.yaml
+++ b/.ci_support/win_64_numpy1.22python3.9.____cpythonvariantnovtk.yaml
@@ -1,0 +1,25 @@
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- vs2019
+numpy:
+- '1.22'
+occt:
+- 7.7.2
+pin_run_as_build:
+  occt:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+target_platform:
+- win-64
+variant:
+- novtk
+zip_keys:
+- - python
+  - numpy

--- a/.ci_support/win_64_numpy1.23python3.11.____cpythonvariantall.yaml
+++ b/.ci_support/win_64_numpy1.23python3.11.____cpythonvariantall.yaml
@@ -1,0 +1,25 @@
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- vs2019
+numpy:
+- '1.23'
+occt:
+- 7.7.2
+pin_run_as_build:
+  occt:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+target_platform:
+- win-64
+variant:
+- all
+zip_keys:
+- - python
+  - numpy

--- a/.ci_support/win_64_numpy1.23python3.11.____cpythonvariantnovtk.yaml
+++ b/.ci_support/win_64_numpy1.23python3.11.____cpythonvariantnovtk.yaml
@@ -1,17 +1,11 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
-cxx_compiler_version:
-- '16'
-macos_machine:
-- x86_64-apple-darwin13.4.0
+- vs2019
 numpy:
-- '1.22'
+- '1.23'
 occt:
 - 7.7.2
 pin_run_as_build:
@@ -21,9 +15,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.11.* *_cpython
 target_platform:
-- osx-64
+- win-64
+variant:
+- novtk
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/win_64_numpy1.26python3.12.____cpythonvariantall.yaml
+++ b/.ci_support/win_64_numpy1.26python3.12.____cpythonvariantall.yaml
@@ -5,7 +5,7 @@ channel_targets:
 cxx_compiler:
 - vs2019
 numpy:
-- '1.22'
+- '1.26'
 occt:
 - 7.7.2
 pin_run_as_build:
@@ -15,9 +15,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.12.* *_cpython
 target_platform:
 - win-64
+variant:
+- all
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/win_64_numpy1.26python3.12.____cpythonvariantnovtk.yaml
+++ b/.ci_support/win_64_numpy1.26python3.12.____cpythonvariantnovtk.yaml
@@ -1,0 +1,25 @@
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- vs2019
+numpy:
+- '1.26'
+occt:
+- 7.7.2
+pin_run_as_build:
+  occt:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+target_platform:
+- win-64
+variant:
+- novtk
+zip_keys:
+- - python
+  - numpy

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -28,13 +28,15 @@ conda-build:
 pkgs_dirs:
   - ${FEEDSTOCK_ROOT}/build_artifacts/pkg_cache
   - /opt/conda/pkgs
+solver: libmamba
 
 CONDARC
+export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=3
+    pip mamba conda-build conda-forge-ci-setup=4
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=3
+    pip mamba conda-build conda-forge-ci-setup=4
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -63,6 +65,12 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
   cp "${FEEDSTOCK_ROOT}/LICENSE.txt" "${RECIPE_ROOT}/recipe-scripts-license.txt"
 fi
 
+if [[ "${sha:-}" == "" ]]; then
+  pushd ${FEEDSTOCK_ROOT}
+  sha=$(git rev-parse HEAD)
+  popd
+fi
+
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
@@ -74,9 +82,10 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
-    conda mambabuild "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
+        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
+        --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
     ( startgroup "Validating outputs" ) 2> /dev/null
 
     validate_recipe_outputs "${FEEDSTOCK_NAME}"

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -91,6 +91,9 @@ docker run ${DOCKER_RUN_ARGS} \
            -e CPU_COUNT \
            -e BUILD_WITH_CONDA_DEBUG \
            -e BUILD_OUTPUT_ID \
+           -e flow_run_id \
+           -e remote_url \
+           -e sha \
            -e BINSTAR_TOKEN \
            -e FEEDSTOCK_TOKEN \
            -e STAGING_BINSTAR_TOKEN \

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -22,11 +22,13 @@ bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
 
 source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
 conda activate base
+export CONDA_SOLVER="libmamba"
+export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 mamba install --update-specs --quiet --yes --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=3
+    pip mamba conda-build conda-forge-ci-setup=4
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=3
+    pip mamba conda-build conda-forge-ci-setup=4
 
 
 
@@ -43,6 +45,10 @@ if [[ "${CI:-}" != "" ]]; then
   /usr/bin/sudo -k
 else
   echo -e "\n\nNot mangling homebrew as we are not running in CI"
+fi
+
+if [[ "${sha:-}" == "" ]]; then
+  sha=$(git rev-parse HEAD)
 fi
 
 echo -e "\n\nRunning the build setup script."
@@ -75,9 +81,10 @@ else
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
     fi
 
-    conda mambabuild ./recipe -m ./.ci_support/${CONFIG}.yaml \
+    conda build ./recipe -m ./.ci_support/${CONFIG}.yaml \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
+        --clobber-file ./.ci_support/clobber_${CONFIG}.yaml \
+        --extra-meta flow_run_id="$flow_run_id" remote_url="$remote_url" sha="$sha"
     ( startgroup "Validating outputs" ) 2> /dev/null
 
     validate_recipe_outputs "${FEEDSTOCK_NAME}"

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -17,10 +17,14 @@ call :start_group "Configuring conda"
 
 :: Activate the base conda environment
 call activate base
+:: Configure the solver
+set "CONDA_SOLVER=libmamba"
+if !errorlevel! neq 0 exit /b !errorlevel!
+set "CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1"
 
 :: Provision the necessary dependencies to build the recipe later
 echo Installing dependencies
-mamba.exe install "python=3.10" pip mamba conda-build boa conda-forge-ci-setup=3 -c conda-forge --strict-channel-priority --yes
+mamba.exe install "python=3.10" pip mamba conda-build conda-forge-ci-setup=4 -c conda-forge --strict-channel-priority --yes
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 :: Set basic configuration
@@ -41,11 +45,15 @@ if NOT [%HOST_PLATFORM%] == [%BUILD_PLATFORM%] (
     set "EXTRA_CB_OPTIONS=%EXTRA_CB_OPTIONS% --no-test"
 )
 
+if NOT [%flow_run_id%] == [] (
+    set "EXTRA_CB_OPTIONS=%EXTRA_CB_OPTIONS% --extra-meta flow_run_id=%flow_run_id% remote_url=%remote_url% sha=%sha%"
+)
+
 call :end_group
 
 :: Build the recipe
 echo Building recipe
-conda.exe mambabuild "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
+conda.exe build "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 :: Prepare some environment variables for the upload step

--- a/README.md
+++ b/README.md
@@ -34,143 +34,283 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_numpy1.22python3.10.____cpython</td>
+              <td>linux_64_numpy1.22python3.10.____cpythonvariantall</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.22python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.22python3.10.____cpythonvariantall" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_numpy1.22python3.8.____cpython</td>
+              <td>linux_64_numpy1.22python3.10.____cpythonvariantnovtk</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.22python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.22python3.10.____cpythonvariantnovtk" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_numpy1.22python3.9.____cpython</td>
+              <td>linux_64_numpy1.22python3.8.____cpythonvariantall</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.22python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.22python3.8.____cpythonvariantall" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_numpy1.23python3.11.____cpython</td>
+              <td>linux_64_numpy1.22python3.8.____cpythonvariantnovtk</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.23python3.11.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.22python3.8.____cpythonvariantnovtk" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_numpy1.26python3.12.____cpython</td>
+              <td>linux_64_numpy1.22python3.9.____cpythonvariantall</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.26python3.12.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.22python3.9.____cpythonvariantall" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.22python3.10.____cpython</td>
+              <td>linux_64_numpy1.22python3.9.____cpythonvariantnovtk</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.22python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.22python3.9.____cpythonvariantnovtk" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.22python3.8.____cpython</td>
+              <td>linux_64_numpy1.23python3.11.____cpythonvariantall</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.22python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.23python3.11.____cpythonvariantall" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.22python3.9.____cpython</td>
+              <td>linux_64_numpy1.23python3.11.____cpythonvariantnovtk</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.22python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.23python3.11.____cpythonvariantnovtk" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.23python3.11.____cpython</td>
+              <td>linux_64_numpy1.26python3.12.____cpythonvariantall</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.23python3.11.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.26python3.12.____cpythonvariantall" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.26python3.12.____cpython</td>
+              <td>linux_64_numpy1.26python3.12.____cpythonvariantnovtk</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.26python3.12.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.26python3.12.____cpythonvariantnovtk" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_numpy1.22python3.10.____cpython</td>
+              <td>osx_64_numpy1.22python3.10.____cpythonvariantall</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy1.22python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.22python3.10.____cpythonvariantall" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_numpy1.22python3.8.____cpython</td>
+              <td>osx_64_numpy1.22python3.10.____cpythonvariantnovtk</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy1.22python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.22python3.10.____cpythonvariantnovtk" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_numpy1.22python3.9.____cpython</td>
+              <td>osx_64_numpy1.22python3.8.____cpythonvariantall</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy1.22python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.22python3.8.____cpythonvariantall" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_numpy1.23python3.11.____cpython</td>
+              <td>osx_64_numpy1.22python3.8.____cpythonvariantnovtk</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy1.23python3.11.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.22python3.8.____cpythonvariantnovtk" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_numpy1.26python3.12.____cpython</td>
+              <td>osx_64_numpy1.22python3.9.____cpythonvariantall</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy1.26python3.12.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.22python3.9.____cpythonvariantall" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_numpy1.22python3.10.____cpython</td>
+              <td>osx_64_numpy1.22python3.9.____cpythonvariantnovtk</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.22python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.22python3.9.____cpythonvariantnovtk" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_numpy1.22python3.8.____cpython</td>
+              <td>osx_64_numpy1.23python3.11.____cpythonvariantall</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.22python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.23python3.11.____cpythonvariantall" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_numpy1.22python3.9.____cpython</td>
+              <td>osx_64_numpy1.23python3.11.____cpythonvariantnovtk</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.22python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.23python3.11.____cpythonvariantnovtk" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_numpy1.23python3.11.____cpython</td>
+              <td>osx_64_numpy1.26python3.12.____cpythonvariantall</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.23python3.11.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.26python3.12.____cpythonvariantall" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_numpy1.26python3.12.____cpython</td>
+              <td>osx_64_numpy1.26python3.12.____cpythonvariantnovtk</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.26python3.12.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.26python3.12.____cpythonvariantnovtk" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_numpy1.22python3.10.____cpythonvariantall</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy1.22python3.10.____cpythonvariantall" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_numpy1.22python3.10.____cpythonvariantnovtk</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy1.22python3.10.____cpythonvariantnovtk" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_numpy1.22python3.8.____cpythonvariantall</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy1.22python3.8.____cpythonvariantall" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_numpy1.22python3.8.____cpythonvariantnovtk</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy1.22python3.8.____cpythonvariantnovtk" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_numpy1.22python3.9.____cpythonvariantall</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy1.22python3.9.____cpythonvariantall" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_numpy1.22python3.9.____cpythonvariantnovtk</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy1.22python3.9.____cpythonvariantnovtk" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_numpy1.23python3.11.____cpythonvariantall</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy1.23python3.11.____cpythonvariantall" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_numpy1.23python3.11.____cpythonvariantnovtk</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy1.23python3.11.____cpythonvariantnovtk" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_numpy1.26python3.12.____cpythonvariantall</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy1.26python3.12.____cpythonvariantall" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_numpy1.26python3.12.____cpythonvariantnovtk</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy1.26python3.12.____cpythonvariantnovtk" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_numpy1.22python3.10.____cpythonvariantall</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.22python3.10.____cpythonvariantall" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_numpy1.22python3.10.____cpythonvariantnovtk</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.22python3.10.____cpythonvariantnovtk" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_numpy1.22python3.8.____cpythonvariantall</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.22python3.8.____cpythonvariantall" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_numpy1.22python3.8.____cpythonvariantnovtk</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.22python3.8.____cpythonvariantnovtk" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_numpy1.22python3.9.____cpythonvariantall</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.22python3.9.____cpythonvariantall" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_numpy1.22python3.9.____cpythonvariantnovtk</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.22python3.9.____cpythonvariantnovtk" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_numpy1.23python3.11.____cpythonvariantall</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.23python3.11.____cpythonvariantall" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_numpy1.23python3.11.____cpythonvariantnovtk</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.23python3.11.____cpythonvariantnovtk" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_numpy1.26python3.12.____cpythonvariantall</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.26python3.12.____cpythonvariantall" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_numpy1.26python3.12.____cpythonvariantnovtk</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9148&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pythonocc-core-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.26python3.12.____cpythonvariantnovtk" alt="variant">
                 </a>
               </td>
             </tr>
@@ -254,7 +394,7 @@ available continuous integration services. Thanks to the awesome service provide
 [CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/),
 [Drone](https://cloud.drone.io/welcome), and [TravisCI](https://travis-ci.com/)
 it is possible to build and upload installable packages to the
-[conda-forge](https://anaconda.org/conda-forge) [Anaconda-Cloud](https://anaconda.org/)
+[conda-forge](https://anaconda.org/conda-forge) [anaconda.org](https://anaconda.org/)
 channel for Linux, Windows and OSX respectively.
 
 To manage the continuous integration and simplify feedstock maintenance

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,3 @@
+variant:
+  - novtk
+  - all

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,8 @@
 {% set version = "7.7.2" %}
 
+{% set build = build + 100 %}   # [variant == "novtk"]
+{% set build = build + 200 %}   # [variant == "all"]
+
 package:
   name: pythonocc-core
   version: {{ version }}
@@ -9,7 +12,8 @@ source:
   sha256: 0f6473be2800a64222ef86a3de70e3beaa2320a3839ebde1b4f6e845a369c0d9
 
 build:
-  number: 1
+  string: {{ variant }}_h{{ PKG_HASH }}_{{ build }}
+  number: 2
 
 requirements:
   build:
@@ -24,7 +28,7 @@ requirements:
     - swig 4.1.1
   host:
     - python
-    - occt {{ version }}
+    - occt {{ version }} *{{ variant }}*
     - numpy
   run:
     - python
@@ -33,7 +37,7 @@ requirements:
     - {{ pin_compatible("numpy") }}
     - svgwrite
   run_constrained:
-    - occt {{ version }}
+    - occt {{ version }} *{{ variant }}*
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,7 +51,7 @@ test:
     - pyqt >=5
 
 about:
-  home: http://www.pythonocc.org/
+  home: https://github.com/tpaviot/pythonocc-core
   license: LGPL-3.0
   license_family: LGPL
   license_file: LICENSE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,7 @@
 {% set version = "7.7.2" %}
+{% set build = 2 %}
 
+# Higher number -> Always prioritize "all" variant over "novtk" variant
 {% set build = build + 100 %}   # [variant == "novtk"]
 {% set build = build + 200 %}   # [variant == "all"]
 
@@ -13,7 +15,7 @@ source:
 
 build:
   string: {{ variant }}_h{{ PKG_HASH }}_{{ build }}
-  number: 2
+  number: {{ build }}
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,7 +52,7 @@ test:
 
 about:
   home: https://github.com/tpaviot/pythonocc-core
-  license: LGPL-3.0
+  license: LGPL-3.0-or-later
   license_family: LGPL
   license_file: LICENSE
   summary: python bindings for opencascade (occt)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - numpy
   run:
     - python
-    - occt
+    - occt {{ version }} *{{ variant }}*
     - six
     - {{ pin_compatible("numpy") }}
     - svgwrite


### PR DESCRIPTION
This PR adds support for occt variants (all & novtk). The latter is convenient when you need fewest possible package dependencies and you are not relying on any VTK features compiled in occt.